### PR TITLE
crypto: remove getMnemonicFromPrivateKey

### DIFF
--- a/docs/jsdoc.md
+++ b/docs/jsdoc.md
@@ -306,7 +306,12 @@ Encodes an address from input data bytes.
 Generates 32 bytes of random entropy
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
-**Returns**: <code>string</code> - entropy hexstring  
+**Returns**: <code>string</code> - entropy bytes hexstring  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| len | <code>number</code> | output length (default: 32 bytes) |
+
 <a name="module_crypto.generateRandomArray"></a>
 
 ### crypto.generateRandomArray ⇒ <code>ArrayBuffer</code>
@@ -455,7 +460,7 @@ Get a private key from mnemonic words.
 | Param | Type | Description |
 | --- | --- | --- |
 | mnemonic | <code>string</code> | the mnemonic phrase words |
-| derive | <code>bool</code> | derive a private key using the default HD path, default: true |
+| derive | <code>bool</code> | derive a private key using the default HD path (default: true) |
 
 <a name="module_amino"></a>
 

--- a/docs/jsdoc.md
+++ b/docs/jsdoc.md
@@ -261,9 +261,9 @@ The Ledger signing delegate.
     * [.verifySignature](#module_crypto.verifySignature) ⇒ <code>Buffer</code>
     * [.generateKeyStore](#module_crypto.generateKeyStore)
     * [.getPrivateKeyFromKeyStore](#module_crypto.getPrivateKeyFromKeyStore)
-    * [.getMnemonicFromPrivateKey](#module_crypto.getMnemonicFromPrivateKey)
     * [.generateMnemonic](#module_crypto.generateMnemonic)
-    * [.getPrivateKeyFromMnemonic](#module_crypto.getPrivateKeyFromMnemonic)
+    * [.validateMnemonic](#module_crypto.validateMnemonic) ⇒ <code>bool</code>
+    * [.getPrivateKeyFromMnemonic](#module_crypto.getPrivateKeyFromMnemonic) ⇒ <code>string</code>
 
 <a name="module_crypto.decodeAddress"></a>
 
@@ -303,9 +303,10 @@ Encodes an address from input data bytes.
 <a name="module_crypto.generatePrivateKey"></a>
 
 ### crypto.generatePrivateKey ⇒ <code>string</code>
-Generates a random private key
+Generates 32 bytes of random entropy
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
+**Returns**: <code>string</code> - entropy hexstring  
 <a name="module_crypto.generateRandomArray"></a>
 
 ### crypto.generateRandomArray ⇒ <code>ArrayBuffer</code>
@@ -321,7 +322,7 @@ Generates an arrayBuffer filled with random bits.
 
 ### crypto.getPublicKey ⇒ <code>Elliptic.PublicKey</code>
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
-**Returns**: <code>Elliptic.PublicKey</code> - public key  
+**Returns**: <code>Elliptic.PublicKey</code> - public key hexstring  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -333,6 +334,7 @@ Generates an arrayBuffer filled with random bits.
 Calculates the public key from a given private key.
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
+**Returns**: <code>string</code> - public key hexstring  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -403,54 +405,57 @@ Verifies a signature (64 byte <r,s>) given the sign bytes and public key.
 <a name="module_crypto.generateKeyStore"></a>
 
 ### crypto.generateKeyStore
-Generates a keystore file based on given private key and password.
+Generates a keystore based on given private key and password.
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| privateKey | <code>string</code> | Private Key. |
-| password | <code>string</code> | Password. |
+| privateKey | <code>string</code> | the private key |
+| password | <code>string</code> | the password |
 
 <a name="module_crypto.getPrivateKeyFromKeyStore"></a>
 
 ### crypto.getPrivateKeyFromKeyStore
-Generates privatekey based on keystore and password
+Gets a private key from a keystore given its password.
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| keystore | <code>string</code> | keystore file json format. |
-| password | <code>string</code> | Password. |
-
-<a name="module_crypto.getMnemonicFromPrivateKey"></a>
-
-### crypto.getMnemonicFromPrivateKey
-Gets Mnemonic from a private key.
-
-**Kind**: static constant of [<code>crypto</code>](#module_crypto)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| privateKey | <code>string</code> | the private key hexstring |
+| keystore | <code>string</code> | the keystore in json format |
+| password | <code>string</code> | the password. |
 
 <a name="module_crypto.generateMnemonic"></a>
 
 ### crypto.generateMnemonic
-Generate Mnemonic (length=== 15)
+Generates mnemonic phrase words using random entropy.
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
+<a name="module_crypto.validateMnemonic"></a>
+
+### crypto.validateMnemonic ⇒ <code>bool</code>
+Validates mnemonic phrase words.
+
+**Kind**: static constant of [<code>crypto</code>](#module_crypto)  
+**Returns**: <code>bool</code> - validation result  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| mnemonic | <code>string</code> | the mnemonic phrase words |
+
 <a name="module_crypto.getPrivateKeyFromMnemonic"></a>
 
-### crypto.getPrivateKeyFromMnemonic
-Get privatekey from mnemonic.
+### crypto.getPrivateKeyFromMnemonic ⇒ <code>string</code>
+Get a private key from mnemonic words.
 
 **Kind**: static constant of [<code>crypto</code>](#module_crypto)  
+**Returns**: <code>string</code> - hexstring  
 
-| Type |
-| --- |
-| <code>mnemonic</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| mnemonic | <code>string</code> | the mnemonic phrase words |
+| derive | <code>bool</code> | derive a private key using the default HD path, default: true |
 
 <a name="module_amino"></a>
 

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -247,9 +247,17 @@ export const getPrivateKeyFromKeyStore = (keystore, password) => {
 export const generateMnemonic = () => bip39.generateMnemonic(MNEMONIC_LEN)
 
 /**
+ * Validates mnemonic phrase words.
+ * @param {string} mnemonic the mnemonic phrase words
+ * @return {bool} validation result
+ */
+export const validateMnemonic = bip39.validateMnemonic
+
+/**
  * Get a private key from mnemonic words.
  * @param {string} mnemonic the mnemonic phrase words
  * @param {bool} derive derive a private key using the default HD path, default: true
+ * @return {string} hexstring
  */
 export const getPrivateKeyFromMnemonic = (mnemonic, derive = true) => {
   if(!bip39.validateMnemonic(mnemonic)){

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -67,9 +67,10 @@ export const encodeAddress = (value, prefix = "tbnb", type = "hex") => {
 
 /**
  * Generates 32 bytes of random entropy
- * @returns {string} entropy hexstring
+ * @param {number} len output length (default: 32 bytes)
+ * @returns {string} entropy bytes hexstring
  */
-export const generatePrivateKey = () => ab2hexstring(csprng(PRIVKEY_LEN))
+export const generatePrivateKey = (len = PRIVKEY_LEN) => ab2hexstring(csprng(len))
 
 /**
  * Generates an arrayBuffer filled with random bits.
@@ -256,7 +257,7 @@ export const validateMnemonic = bip39.validateMnemonic
 /**
  * Get a private key from mnemonic words.
  * @param {string} mnemonic the mnemonic phrase words
- * @param {bool} derive derive a private key using the default HD path, default: true
+ * @param {bool} derive derive a private key using the default HD path (default: true)
  * @return {string} hexstring
  */
 export const getPrivateKeyFromMnemonic = (mnemonic, derive = true) => {


### PR DESCRIPTION
The mnemonic represents a seed, this method is simply confusing to have in here.

**BREAKING CHANGES**

* Removed `crypto.getMnemonicFromPrivateKey`

**CHANGES**

* Added `derive` argument to `crypto.getPrivateKeyFromMnemonic` which makes key derivation optional. Default: `true`
* Added `crypto.validateMnemonic`
* Changed `generatePrivateKey` to take an optional `len` arg (default: 32)
