### PR TITLE
Keystore sha3 macs

### DIFF
--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -205,7 +205,7 @@ describe("BncClient test", async () => {
     expect(markets.length).toBeGreaterThan(0)
     expect(markets[0]).toHaveProperty("base_asset_symbol")
     expect(markets[0]).toHaveProperty("quote_asset_symbol")
-    expect(markets[0]).toHaveProperty("price")
+    expect(markets[0]).toHaveProperty("list_price")
     expect(markets[0]).toHaveProperty("tick_size")
     expect(markets[0]).toHaveProperty("lot_size")
   })

--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -6,7 +6,7 @@ import Transaction from "../src/tx"
 /* make sure the address from the mnemonic has balances, or the case will failed */
 const mnemonic = "offer caution gift cross surge pretty orange during eye soldier popular holiday mention east eight office fashion ill parrot vault rent devote earth cousin"
 
-const keystore = {"version":1,"id":"dfb09873-f16f-48c6-a6b8-bb5a705c47a7","address":"bnc1dxj068zgk007fchefj9n8tq06pcuce5ypqm5zk","crypto":{"ciphertext":"33b7439a8d64d73357dc91f88a6b3a45e7303717664d17daf8e8dc1cc708fa4b","cipherparams":{"iv":"88c726d70cd0437bfdb2312dc60103fc"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"ad10ef544417d4a25914dec3d908882686dd9d793b5c484b76fd5aa575cf54b9","c":262144,"prf":"hmac-sha256"},"mac":"f7cc301d18c97c71741492b8029544952ad5567a733971deb49fd3eb03ee696e"}}
+const keystore = {"version":1,"id":"73a811d0-5e31-4a0e-9b3a-a2a457ccbd7b","crypto":{"ciphertext":"3b","cipherparams":{"iv":"56d59d999578a0364c59934128dd215d"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"781849b3477252928cfbe5d62180a755dce1e5b2569b02f6f14e7f46a0740687","c":262144,"prf":"hmac-sha256"},"mac":"6a967b9dad5062eac3dbc9db4e30a8f2efa60f60403aa9ea0345e50cdfb5e9d86343f5808b7e2f51b062f7c7f24189723acd4a94568e6a72bb63e6345e988c0f"}}
 
 const targetAddress = "tbnb1hgm0p7khfk85zpz5v0j8wnej3a90w709zzlffd"
 

--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -6,18 +6,27 @@ import Transaction from "../src/tx"
 /* make sure the address from the mnemonic has balances, or the case will failed */
 const mnemonic = "offer caution gift cross surge pretty orange during eye soldier popular holiday mention east eight office fashion ill parrot vault rent devote earth cousin"
 
-const keystore = {"version":1,"id":"73a811d0-5e31-4a0e-9b3a-a2a457ccbd7b","crypto":{"ciphertext":"3b","cipherparams":{"iv":"56d59d999578a0364c59934128dd215d"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"781849b3477252928cfbe5d62180a755dce1e5b2569b02f6f14e7f46a0740687","c":262144,"prf":"hmac-sha256"},"mac":"6a967b9dad5062eac3dbc9db4e30a8f2efa60f60403aa9ea0345e50cdfb5e9d86343f5808b7e2f51b062f7c7f24189723acd4a94568e6a72bb63e6345e988c0f"}}
+const keystores = {
+  // keystore with sha3 mac
+  new: {"version":1,"id":"73a811d0-5e31-4a0e-9b3a-a2a457ccbd7b","crypto":{"ciphertext":"3b","cipherparams":{"iv":"56d59d999578a0364c59934128dd215d"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"781849b3477252928cfbe5d62180a755dce1e5b2569b02f6f14e7f46a0740687","c":262144,"prf":"hmac-sha256"},"mac":"6a967b9dad5062eac3dbc9db4e30a8f2efa60f60403aa9ea0345e50cdfb5e9d86343f5808b7e2f51b062f7c7f24189723acd4a94568e6a72bb63e6345e988c0f"}},
+  // keystore with sha256 mac
+  legacy: {"version":1,"id":"dfb09873-f16f-48c6-a6b8-bb5a705c47a7","address":"bnc1dxj068zgk007fchefj9n8tq06pcuce5ypqm5zk","crypto":{"ciphertext":"33b7439a8d64d73357dc91f88a6b3a45e7303717664d17daf8e8dc1cc708fa4b","cipherparams":{"iv":"88c726d70cd0437bfdb2312dc60103fc"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"ad10ef544417d4a25914dec3d908882686dd9d793b5c484b76fd5aa575cf54b9","c":262144,"prf":"hmac-sha256"},"mac":"f7cc301d18c97c71741492b8029544952ad5567a733971deb49fd3eb03ee696e"}},
+  // keystore with bad mac
+  badMac: {"version":1,"id":"dfb09873-f16f-48c6-a6b8-bb5a705c47a7","address":"bnc1dxj068zgk007fchefj9n8tq06pcuce5ypqm5zk","crypto":{"ciphertext":"33b7439a8d64d73357dc91f88a6b3a45e7303717664d17daf8e8dc1cc708fa4b","cipherparams":{"iv":"88c726d70cd0437bfdb2312dc60103fc"},"cipher":"aes-256-ctr","kdf":"pbkdf2","kdfparams":{"dklen":32,"salt":"ad10ef544417d4a25914dec3d908882686dd9d793b5c484b76fd5aa575cf54b9","c":262144,"prf":"hmac-sha256"},"mac":"x7cc301d18c97c71741492b8029544952ad5567a733971deb49fd3eb03ee696e"}},
+}
 
 const targetAddress = "tbnb1hgm0p7khfk85zpz5v0j8wnej3a90w709zzlffd"
 
-const getClient = async (useAwaitSetPrivateKey = true) => {
+const getClient = async (useAwaitSetPrivateKey = true, doNotSetPrivateKey = false) => {
   const client = new BncClient("https://testnet-dex.binance.org")
   await client.initChain()
   const privateKey = crypto.getPrivateKeyFromMnemonic(mnemonic)
-  if (useAwaitSetPrivateKey) {
-    await client.setPrivateKey(privateKey)
-  } else {
-    client.setPrivateKey(privateKey) // test without `await`
+  if (!doNotSetPrivateKey) {
+    if (useAwaitSetPrivateKey) {
+      await client.setPrivateKey(privateKey)
+    } else {
+      client.setPrivateKey(privateKey) // test without `await`
+    }
   }
   // use default delegates (signing, broadcast)
   client.useDefaultSigningDelegate()
@@ -54,7 +63,7 @@ describe("BncClient test", async () => {
   })
 
   it("create account with keystore", async () => {
-    const client = await getClient(false)
+    const client = await getClient(false, true)
     const res = client.createAccountWithKeystore("12345678")
     expect(res.address).toBeTruthy()
     expect(res.privateKey).toBeTruthy()
@@ -70,10 +79,24 @@ describe("BncClient test", async () => {
   })
 
   it("recover account from keystore", async () => {
-    const client = await getClient(false)
-    const res = client.recoverAccountFromKeystore(keystore, "12345qwert!S")
+    const client = await getClient(false, true)
+    const res = client.recoverAccountFromKeystore(keystores.new, "12345qwert!S")
     expect(res.address).toBeTruthy()
     expect(res.privateKey).toBeTruthy()
+  })
+
+  it("recover account from legacy (sha256) keystore", async () => {
+    const client = await getClient(false, true)
+    const res = client.recoverAccountFromKeystore(keystores.legacy, "12345qwert!S")
+    expect(res.address).toBeTruthy()
+    expect(res.privateKey).toBeTruthy()
+  })
+
+  it("recover account from bad mac keystore", async () => {
+    const client = await getClient(false, true)
+    expect(() => {
+      client.recoverAccountFromKeystore(keystores.badMac, "12345qwert!S")
+    }).toThrowError()
   })
 
   it("recover account from mneomnic", async () => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@
  */
 
 import hexEncoding from "crypto-js/enc-hex"
+import SHA3 from "crypto-js/sha3"
 import SHA256 from "crypto-js/sha256"
 import RIPEMD160 from "crypto-js/ripemd160"
 
@@ -201,8 +202,20 @@ export const ensureHex = str => {
 }
 
 /**
- * Performs a SHA256 followed by a RIPEMD160.
- * @param {string} hex - String to hash
+ * Computes a single SHA3 (Keccak) digest.
+ * @param {string} hex message to hash
+ * @returns {string} hash output
+ */
+export const sha3 = (hex) => {
+  if (typeof hex !== "string") throw new Error("sha3 expects a hex string")
+  if (hex.length % 2 !== 0) throw new Error(`invalid hex string length: ${hex}`)
+  const hexEncoded = hexEncoding.parse(hex)
+  return SHA3(hexEncoded).toString()
+}
+
+/**
+ * Computes a SHA256 followed by a RIPEMD160.
+ * @param {string} hex message to hash
  * @returns {string} hash output
  */
 export const sha256ripemd160 = (hex) => {
@@ -214,8 +227,8 @@ export const sha256ripemd160 = (hex) => {
 }
 
 /**
- * Performs a single SHA256.
- * @param {string} hex - String to hash
+ * Computes a single SHA256 digest.
+ * @param {string} hex message to hash
  * @returns {string} hash output
  */
 export const sha256 = (hex) => {
@@ -224,4 +237,3 @@ export const sha256 = (hex) => {
   const hexEncoded = hexEncoding.parse(hex)
   return SHA256(hexEncoded).toString()
 }
-

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -202,18 +202,6 @@ export const ensureHex = str => {
 }
 
 /**
- * Computes a single SHA3 (Keccak) digest.
- * @param {string} hex message to hash
- * @returns {string} hash output
- */
-export const sha3 = (hex) => {
-  if (typeof hex !== "string") throw new Error("sha3 expects a hex string")
-  if (hex.length % 2 !== 0) throw new Error(`invalid hex string length: ${hex}`)
-  const hexEncoded = hexEncoding.parse(hex)
-  return SHA3(hexEncoded).toString()
-}
-
-/**
  * Computes a SHA256 followed by a RIPEMD160.
  * @param {string} hex message to hash
  * @returns {string} hash output
@@ -236,4 +224,16 @@ export const sha256 = (hex) => {
   if (hex.length % 2 !== 0) throw new Error(`invalid hex string length: ${hex}`)
   const hexEncoded = hexEncoding.parse(hex)
   return SHA256(hexEncoded).toString()
+}
+
+/**
+ * Computes a single SHA3 (Keccak) digest.
+ * @param {string} hex message to hash
+ * @returns {string} hash output
+ */
+export const sha3 = (hex) => {
+  if (typeof hex !== "string") throw new Error("sha3 expects a hex string")
+  if (hex.length % 2 !== 0) throw new Error(`invalid hex string length: ${hex}`)
+  const hexEncoded = hexEncoding.parse(hex)
+  return SHA3(hexEncoded).toString()
 }

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -37,11 +37,16 @@ class HttpRequest {
         return { result: response.data, status: response.status }
       }).catch(err => {
         // TODO: what if it's not json?
-        console.error("error in HttpRequest#request", err)
-        const msgObj = err.response && err.response.data && JSON.parse(err.response.data.message)
-        let error = new Error(msgObj.message)
-        error.code = msgObj.code
-        error.abci_code = msgObj.abci_code
+        console.error("error in HttpRequest#request", err, err.statusCode)
+        let error = err
+        try {
+          const msgObj = err.response && err.response.data && JSON.parse(err.response.data.message)
+          error = new Error(msgObj.message)
+          error.code = msgObj.code
+          error.abci_code = msgObj.abci_code
+        } catch (err) {
+          throw error
+        }
         throw error
       })
   }


### PR DESCRIPTION
* Write keystores with sha3 macs (aligns with Ethereum's web3 secrets storage spec)
* Reads keystores with both sha3 and sha256 (tries both) macs
* Test updates

closes #92 