### PR TITLE
Release v2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binance-chain/javascript-sdk",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
* Keystore integrity check hashes use sha3, but ones using legacy sha256 still work (#112)
* Updated Ledger tests for app v1.1.3 (#113)
