### PR TITLE
client: fix typo in recoverAccountFromMnemonic

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -556,13 +556,17 @@ export class BncClient {
    * address
    * }
    */
-  recoverAccountFromMneomnic(mneomnic){
-    const privateKey = crypto.getPrivateKeyFromMnemonic(mneomnic)
+  recoverAccountFromMnemonic(mnemonic){
+    const privateKey = crypto.getPrivateKeyFromMnemonic(mnemonic)
     const address = crypto.getAddressFromPrivateKey(privateKey, this.addressPrefix)
     return {
       privateKey,
       address
     }
+  }
+  // support an old method name containing a typo
+  recoverAccountFromMneomnic(mnemonic){
+    return this.recoverAccountFromMnemonic(mnemonic)
   }
 
   /**


### PR DESCRIPTION
`recoverAccountFromMneomnic` -> `recoverAccountFromMnemonic`
Backward compatibility preserved.
