### PR TITLE
Fix: zero sequence calls out to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@binance-chain/javascript-sdk",
-  "version": "2.14.7",
+  "version": "2.14.8",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "scripts": {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -149,7 +149,7 @@ export class BncClient {
   /**
    * Sets the client's private key for calls made by this client. Asynchronous.
    * @param {string} privateKey the private key hexstring
-   * @param {boolean} localOnly set this to true if you will supply an account_number yourself via `setAccountNumber`. Warning: You must do this!
+   * @param {boolean} localOnly set this to true if you will supply an account_number yourself via `setAccountNumber`. Warning: You must do that if you set this to true!
    * @return {Promise}
    */
   async setPrivateKey(privateKey, localOnly = false) {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -148,21 +148,33 @@ export class BncClient {
 
   /**
    * Sets the client's private key for calls made by this client. Asynchronous.
+   * @param {string} privateKey the private key hexstring
+   * @param {boolean} localOnly set this to true if you will supply an account_number yourself via `setAccountNumber`. Warning: You must do this!
    * @return {Promise}
    */
-  async setPrivateKey(privateKey) {
+  async setPrivateKey(privateKey, localOnly = false) {
     if (privateKey !== this.privateKey) {
       const address = crypto.getAddressFromPrivateKey(privateKey, this.addressPrefix)
       if (!address) throw new Error("address is falsy: ${address}. invalid private key?")
       if (address === this.address) return this // safety
       this.privateKey = privateKey
       this.address = address
-      // _setPkPromise used in _sendTransaction for non-await calls
-      const promise = this._setPkPromise = this._httpClient.request("get", `${api.getAccount}/${address}`)
-      const data = await promise
-      this.account_number = data.result.account_number
+      if (!localOnly) {
+        // _setPkPromise is used in _sendTransaction for non-await calls
+        const promise = this._setPkPromise = this._httpClient.request("get", `${api.getAccount}/${address}`)
+        const data = await promise
+        this.account_number = data.result.account_number
+      }
     }
     return this
+  }
+
+  /**
+   * Sets the client's account number.
+   * @param {boolean} accountNumber
+   */
+  setAccountNumber(accountNumber) {
+    this.account_number = accountNumber
   }
 
   /**
@@ -529,7 +541,7 @@ export class BncClient {
    * @return {Transaction} signed transaction
    */
   async _prepareTransaction(msg, stdSignMsg, address, sequence = null, memo = "") {
-    if ((!this.account_number || !sequence) && address) {
+    if ((!this.account_number || (sequence !== 0 && !sequence)) && address) {
       const data = await this._httpClient.request("get", `${api.getAccount}/${address}`)
       sequence = data.result.sequence
       this.account_number = data.result.account_number


### PR DESCRIPTION
**FIXES**
* Bug Fix: A zero sequence was still calling out to the account API on L544.

**CHANGES**
* Added: A method to set the account number on the client: `setAccountNumber`
* Added: An optional `localOnly` boolean argument to `setPrivateKey` which skips populating `account_number` via the central API.
* Bumped version to v2.14.8
