### PR TITLE
Add getDepth, getTransactions & getOpenOrders to client

### DIFF
--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -264,6 +264,32 @@ it("get markets works", async () => {
   expect(markets[0]).toHaveProperty("lot_size")
 })
 
+it("get transactions works", async () => {
+  const client = await getClient(false)
+  const { result: transactions, status } = await client.getTransactions(targetAddress)
+  expect(status).toBe(200)
+  expect(transactions).toHaveProperty("tx")
+  expect(transactions).toHaveProperty("total")
+})
+
+it("get open orders works", async () => {
+  const client = await getClient(false)
+  const { result: orders, status } = await client.getOpenOrders(targetAddress)
+  expect(status).toBe(200)
+  expect(orders).toHaveProperty("order")
+  expect(orders).toHaveProperty("total")
+})
+
+it("get depth works", async () => {
+  const symbol = "BNB_USDT.B-B7C"
+  const client = await getClient(false)
+  const { result: depth, status } = await client.getDepth(symbol)
+  expect(status).toBe(200)
+  expect(depth).toHaveProperty("bids")
+  expect(depth).toHaveProperty("asks")
+  expect(depth).toHaveProperty("height")
+})
+
 it("check number when transfer", async () => {
   const client = await getClient(true)
   const addr = crypto.getAddressFromPrivateKey(client.privateKey)

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -16,7 +16,10 @@ export const api = {
   broadcast: "/api/v1/broadcast",
   nodeInfo: "/api/v1/node-info",
   getAccount: "/api/v1/account",
-  getMarkets: "/api/v1/markets"
+  getMarkets: "/api/v1/markets",
+  getOpenOrders: "/api/v1/orders/open",
+  getDepth: "/api/v1/depth",
+  getTransactions: "/api/v1/transactions"
 }
 
 const NETWORK_PREFIX_MAPPING = {
@@ -651,6 +654,53 @@ export class BncClient {
       return data
     } catch (err) {
       console.warn("getMarkets error", err)
+      return []
+    }
+  }
+
+  /**
+   * get transactions for an account
+   * @param {String} address optional address
+   * @param {Number} offset from beggining, default 0
+   * @return {Promise} resolves with http response
+   */
+  async getTransactions(address = this.address, offset = 0) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTransactions}?address=${address}&offset=${offset}`)
+      return data
+    } catch (err) {
+      console.warn("getTransactions error", err)
+      return []
+    }
+  }
+
+  /**
+   * get depth for a given market
+   * @param {String} symbol the market pair
+   * @return {Promise} resolves with http response
+   */
+  async getDepth(symbol = 'BNB_BUSD-BD1') {
+    try {
+      const data = await this._httpClient.request("get", `${api.getDepth}?symbol=${symbol}`)
+      return data
+    } catch (err) {
+      console.warn("getDepth error", err)
+      return []
+    }
+  }
+
+  /**
+   * get open orders for an address
+   * @param {String} address binance address
+   * @param {String} symbol binance BEP2 symbol
+   * @return {Promise} resolves with http response
+   */
+  async getOpenOrders(address = this.address) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getOpenOrders}?address=${address}`)
+      return data
+    } catch (err) {
+      console.warn("getOpenOrders error", err)
       return []
     }
   }


### PR DESCRIPTION
Add 3 additional functions to the client pursuant to the API documentation.

`getDepth` - Retrieves the depth for a given market pair eg. `RUNE-A1F_BNB` (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1depth)

`getOpenOrders` - Retrieves the current open orders for the address. (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1ordersopen)

`getTransactions` - Retrieves the transaction history for an address. (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1transactions)

Nb. The `getTransactions` function is a basic implementation which only supports `address` and `offset` params, and thus doesn't provide additional params including startTime, endTime etc.