### PR TITLE
Add getDepth, getTransactions, getTx & getOpenOrders to client

### DIFF
--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -272,6 +272,19 @@ it("get transactions works", async () => {
   expect(transactions).toHaveProperty("total")
 })
 
+it("get tx works", async () => {
+  const testHash = 'F1C85CF924D3246EE519CE44F96F8F0FF028E509E3B3EE32A25A805EEFB21A4F'
+  const client = await getClient(false)
+  const { result: tx, status } = await client.getTx(testHash)
+  expect(status).toBe(200)
+  expect(tx).toHaveProperty("code")
+  expect(tx).toHaveProperty("data")
+  expect(tx).toHaveProperty("hash")
+  expect(tx).toHaveProperty("height")
+  expect(tx).toHaveProperty("log")
+  expect(tx).toHaveProperty("ok")
+})
+
 it("get open orders works", async () => {
   const client = await getClient(false)
   const { result: orders, status } = await client.getOpenOrders(targetAddress)
@@ -554,4 +567,4 @@ it("list MINT", async ()=>{
   }
 })
 
-// })
+})

--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -264,6 +264,32 @@ it("get markets works", async () => {
   expect(markets[0]).toHaveProperty("lot_size")
 })
 
+it("get transactions works", async () => {
+  const client = await getClient(false)
+  const { result: transactions, status } = await client.getTransactions(targetAddress)
+  expect(status).toBe(200)
+  expect(transactions).toHaveProperty("tx")
+  expect(transactions).toHaveProperty("total")
+})
+
+it("get open orders works", async () => {
+  const client = await getClient(false)
+  const { result: orders, status } = await client.getOpenOrders(targetAddress)
+  expect(status).toBe(200)
+  expect(orders).toHaveProperty("order")
+  expect(orders).toHaveProperty("total")
+})
+
+it("get depth works", async () => {
+  const symbol = "BNB_USDT.B-B7C"
+  const client = await getClient(false)
+  const { result: depth, status } = await client.getDepth(symbol)
+  expect(status).toBe(200)
+  expect(depth).toHaveProperty("bids")
+  expect(depth).toHaveProperty("asks")
+  expect(depth).toHaveProperty("height")
+})
+
 it("check number when transfer", async () => {
   const client = await getClient(true)
   const addr = crypto.getAddressFromPrivateKey(client.privateKey)

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -19,7 +19,8 @@ export const api = {
   getMarkets: "/api/v1/markets",
   getOpenOrders: "/api/v1/orders/open",
   getDepth: "/api/v1/depth",
-  getTransactions: "/api/v1/transactions"
+  getTransactions: "/api/v1/transactions",
+  getTx: "/api/v1/tx"
 }
 
 const NETWORK_PREFIX_MAPPING = {
@@ -670,6 +671,21 @@ export class BncClient {
       return data
     } catch (err) {
       console.warn("getTransactions error", err)
+      return []
+    }
+  }
+
+    /**
+   * get transaction
+   * @param {String} hash the transaction hash
+   * @return {Promise} resolves with http response
+   */
+  async getTx(hash) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTx}/${hash}`)
+      return data
+    } catch (err) {
+      console.warn("getTx error", err)
       return []
     }
   }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -17,7 +17,11 @@ export const api = {
   nodeInfo: "/api/v1/node-info",
   getAccount: "/api/v1/account",
   getMarkets: "/api/v1/markets",
-  getSwaps: "/api/v1/atomic-swaps"
+  getSwaps: "/api/v1/atomic-swaps",
+  getOpenOrders: "/api/v1/orders/open",
+  getDepth: "/api/v1/depth",
+  getTransactions: "/api/v1/transactions",
+  getTx: "/api/v1/tx"
 }
 
 const NETWORK_PREFIX_MAPPING = {
@@ -652,6 +656,68 @@ export class BncClient {
       return data
     } catch (err) {
       console.warn("getMarkets error", err)
+      return []
+    }
+  }
+
+  /**
+   * get transactions for an account
+   * @param {String} address optional address
+   * @param {Number} offset from beggining, default 0
+   * @return {Promise} resolves with http response
+   */
+  async getTransactions(address = this.address, offset = 0) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTransactions}?address=${address}&offset=${offset}`)
+      return data
+    } catch (err) {
+      console.warn("getTransactions error", err)
+      return []
+    }
+  }
+
+  /**
+   * get transaction
+   * @param {String} hash the transaction hash
+   * @return {Promise} resolves with http response
+   */
+  async getTx(hash) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTx}/${hash}`)
+      return data
+    } catch (err) {
+      console.warn("getTx error", err)
+      return []
+    }
+  }
+  
+  /**
+   * get depth for a given market
+   * @param {String} symbol the market pair
+   * @return {Promise} resolves with http response
+   */
+  async getDepth(symbol = 'BNB_BUSD-BD1') {
+    try {
+      const data = await this._httpClient.request("get", `${api.getDepth}?symbol=${symbol}`)
+      return data
+    } catch (err) {
+      console.warn("getDepth error", err)
+      return []
+    }
+  }
+
+  /**
+   * get open orders for an address
+   * @param {String} address binance address
+   * @param {String} symbol binance BEP2 symbol
+   * @return {Promise} resolves with http response
+   */
+  async getOpenOrders(address = this.address) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getOpenOrders}?address=${address}`)
+      return data
+    } catch (err) {
+      console.warn("getOpenOrders error", err)
       return []
     }
   }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -17,10 +17,7 @@ export const api = {
   nodeInfo: "/api/v1/node-info",
   getAccount: "/api/v1/account",
   getMarkets: "/api/v1/markets",
-  getOpenOrders: "/api/v1/orders/open",
-  getDepth: "/api/v1/depth",
-  getTransactions: "/api/v1/transactions",
-  getTx: "/api/v1/tx"
+  getSwaps: "/api/v1/atomic-swaps"
 }
 
 const NETWORK_PREFIX_MAPPING = {
@@ -660,63 +657,50 @@ export class BncClient {
   }
 
   /**
-   * get transactions for an account
-   * @param {String} address optional address
-   * @param {Number} offset from beggining, default 0
-   * @return {Promise} resolves with http response
+   * get atomic swap
+   * @param {String} swapID: ID of an existing swap
+   * @return {Promise} AtomicSwap
    */
-  async getTransactions(address = this.address, offset = 0) {
+  async getSwapByID(swapID) {
     try {
-      const data = await this._httpClient.request("get", `${api.getTransactions}?address=${address}&offset=${offset}`)
+      const data = await this._httpClient.request("get", `${api.getSwaps}/${swapID}`)
       return data
     } catch (err) {
-      console.warn("getTransactions error", err)
-      return []
-    }
-  }
-
-    /**
-   * get transaction
-   * @param {String} hash the transaction hash
-   * @return {Promise} resolves with http response
-   */
-  async getTx(hash) {
-    try {
-      const data = await this._httpClient.request("get", `${api.getTx}/${hash}`)
-      return data
-    } catch (err) {
-      console.warn("getTx error", err)
+      console.warn("query swap by swapID error", err)
       return []
     }
   }
 
   /**
-   * get depth for a given market
-   * @param {String} symbol the market pair
-   * @return {Promise} resolves with http response
+   * query atomic swap list by creator address
+   * @param {String} creator: swap creator address
+   * @param {Number} offset from beginning, default 0
+   * @param {Number} limit, max 1000 is default
+   * @return {Promise} Array of AtomicSwap
    */
-  async getDepth(symbol = 'BNB_BUSD-BD1') {
+  async getSwapByCreator(creator, limit = 100, offset = 0) {
     try {
-      const data = await this._httpClient.request("get", `${api.getDepth}?symbol=${symbol}`)
+      const data = await this._httpClient.request("get", `${api.getSwaps}?fromAddress=${creator}&limit=${limit}&offset=${offset}`)
       return data
     } catch (err) {
-      console.warn("getDepth error", err)
+      console.warn("query swap list by swap creator error", err)
       return []
     }
   }
 
   /**
-   * get open orders for an address
-   * @param {String} address binance address
-   * @param {String} symbol binance BEP2 symbol
-   * @return {Promise} resolves with http response
+   * query atomic swap list by recipient address
+   * @param {String} recipient: the recipient address of the swap
+   * @param {Number} offset from beginning, default 0
+   * @param {Number} limit, max 1000 is default
+   * @return {Promise} Array of AtomicSwap
    */
-  async getOpenOrders(address = this.address) {
+  async getSwapByRecipient(recipient, limit = 100, offset = 0) {
     try {
-      const data = await this._httpClient.request("get", `${api.getOpenOrders}?address=${address}`)
+      const data = await this._httpClient.request("get", `${api.getSwaps}?toAddress=${recipient}&limit=${limit}&offset=${offset}`)
       return data
     } catch (err) {
-      console.warn("getOpenOrders error", err)
+      console.warn("query swap list by swap recipient error", err)
       return []
     }
   }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -16,7 +16,10 @@ export const api = {
   broadcast: "/api/v1/broadcast",
   nodeInfo: "/api/v1/node-info",
   getAccount: "/api/v1/account",
-  getMarkets: "/api/v1/markets"
+  getMarkets: "/api/v1/markets",
+  getOpenOrders: "/api/v1/orders/open",
+  getDepth: "/api/v1/depth",
+  getTransactions: "/api/v1/transactions"
 }
 
 const NETWORK_PREFIX_MAPPING = {
@@ -651,6 +654,53 @@ export class BncClient {
       return data
     } catch (err) {
       console.warn("getMarkets error", err)
+      return []
+    }
+  }
+
+  /**
+   * get transactions for an account
+   * @param {String} address optional address
+   * @param {Number} offset from beggining, default 0
+   * @return {Promise} resolves with http response
+   */
+  async getTransactions(address = this.address, offset = 0) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTransactions}?address=${address}&offset=${offset}`)
+      return data
+    } catch (err) {
+      console.warn("getTransactions error", err)
+      return []
+    }
+  }
+
+  /**
+   * get depth for a given market
+   * @param {String} symbol the market pair
+   * @return {Promise} resolves with http response
+   */
+  async getDepth(symbol = 'BNB_BUSD-BD1') {
+    try {
+      const data = await this._httpClient.request("get", `${api.getDepth}?symbol=${symbol}`)
+      return data
+    } catch (err) {
+      console.warn("getDepth error", err)
+      return []
+    }
+  }
+
+  /**
+   * get open orders for an address
+   * @param {String} address binance address
+   * @param {String} symbol binance BEP2 symbol
+   * @return {Promise} resolves with http response
+   */
+  async getOpenOrders(address = this.address) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getOpenOrders}?address=${address}`)
+      return data
+    } catch (err) {
+      console.warn("getOpenOrders error", err)
       return []
     }
   }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -690,21 +690,6 @@ export class BncClient {
       return []
     }
   }
-
-  /**
-   * get transaction
-   * @param {String} hash the transaction hash
-   * @return {Promise} resolves with http response
-   */
-  async getTx(hash) {
-    try {
-      const data = await this._httpClient.request("get", `${api.getTx}/${hash}`)
-      return data
-    } catch (err) {
-      console.warn("getTx error", err)
-      return []
-    }
-  }
   
   /**
    * get depth for a given market

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -676,6 +676,21 @@ export class BncClient {
     }
   }
 
+    /**
+   * get transaction
+   * @param {String} hash the transaction hash
+   * @return {Promise} resolves with http response
+   */
+  async getTx(hash) {
+    try {
+      const data = await this._httpClient.request("get", `${api.getTx}/${hash}`)
+      return data
+    } catch (err) {
+      console.warn("getTx error", err)
+      return []
+    }
+  }
+
   /**
    * get transaction
    * @param {String} hash the transaction hash

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -21,8 +21,7 @@ export const api = {
   getOpenOrders: "/api/v1/orders/open",
   getDepth: "/api/v1/depth",
   getTransactions: "/api/v1/transactions",
-  getTx: "/api/v1/tx",
-  getSwaps: "/api/v1/atomic-swaps"
+  getTx: "/api/v1/tx"
 }
 
 const NETWORK_PREFIX_MAPPING = {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -264,8 +264,9 @@ export const calculateRandomNumberHash = (randomNumber, timestamp) => {
  * @returns {string} sha256 result
  */
 export const calculateSwapID = (randomNumberHash, sender, senderOtherChain) => {
+  const randomNumberHashBytes = Buffer.from(randomNumberHash, "hex")
   const senderBytes = crypto.decodeAddress(sender)
-  const sendOtherChainBytes = Buffer.from(senderOtherChain, 'utf8')
-  const newBuffer = Buffer.concat([Buffer.from(randomNumberHash, "hex"), senderBytes, sendOtherChainBytes])
+  const sendOtherChainBytes = Buffer.from(senderOtherChain.toLowerCase(), "utf8")
+  const newBuffer = Buffer.concat([randomNumberHashBytes, senderBytes, sendOtherChainBytes])
   return sha256(newBuffer.toString('hex'))
 }


### PR DESCRIPTION
Add 4 additional functions to the client pursuant to the API documentation.

getDepth - Retrieves the depth for a given market pair eg. RUNE-A1F_BNB (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1depth)

getOpenOrders - Retrieves the current open orders for the address. (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1ordersopen)

getTransactions - Retrieves the transaction history for an address. (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1transactions)

getTx - Retrieves the transaction details for a specific hash. (https://docs.binance.org/api-reference/dex-api/paths.html#apiv1txhash)

Nb. The getTransactions function is a basic implementation which only supports address and offset params, and thus doesn't provide additional params including startTime, endTime etc.