### PR TITLE
Transaction type and prefix for SetAccountFlags transactions.

### DIFF
--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -583,4 +583,12 @@ it("list MINT", async ()=>{
   }
 })
 
+it("set account flags", async () => {
+  const client = await getClient(true)
+  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const res = await client.setAccountFlags(addr, 0x01)
+  expect(res.status).toBe(200)
+  expect(res.result[0].code).toBe(0)
+})
+
 })

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -539,6 +539,31 @@ export class BncClient {
   }
 
   /**
+   * Set account flags 
+   * @param {String} address
+   * @param {Number} flags new value of account flags 
+   * @param {Number} sequence optional sequence
+   * @return {Promise} resolves with response (success or fail)
+   */
+  async setAccountFlags(address, flags, sequence = null) {
+    const accCode = crypto.decodeAddress(address)
+
+    const msg = {
+      from: accCode,
+      flags: flags,
+      msgType: "SetAccountFlagsMsg"
+    }
+
+    const signMsg = {
+      flags: flags,
+      from: address
+    }
+
+    const signedTx = await this._prepareTransaction(msg, signMsg, address, sequence, "")
+    return this._broadcastDelegate(signedTx)
+  }
+
+  /**
    * Prepare a serialized raw transaction for sending to the blockchain.
    * @param {Object} msg the msg object
    * @param {Object} stdSignMsg the sign doc object used to generate a signature

--- a/src/tx/index.js
+++ b/src/tx/index.js
@@ -24,7 +24,8 @@ export const TxTypes = {
   HTLTMsg: "HTLTMsg",
   DepositHTLTMsg: "DepositHTLTMsg",
   ClaimHTLTMsg: "ClaimHTLTMsg",
-  RefundHTLTMsg: "RefundHTLTMsg"
+  RefundHTLTMsg: "RefundHTLTMsg",
+  SetAccountFlagsMsg: "SetAccountFlagsMsg"
 }
 
 export const TypePrefixes = {
@@ -49,7 +50,8 @@ export const TypePrefixes = {
   HTLTMsg: "B33F9A24",
   DepositHTLTMsg: "63986496",
   ClaimHTLTMsg: "C1665300",
-  RefundHTLTMsg: "3454A27C"
+  RefundHTLTMsg: "3454A27C",
+  SetAccountFlagsMsg: "BEA6E301"
 }
 
 /**


### PR DESCRIPTION
Consider adding support of [SetAccountFlags](https://docs.binance.org/encoding.html#set-account-flags) message to the Transaction Class

