### PR TITLE
(fix) Fix import of indirect dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bip39": "^3.0.2",
     "bn.js": "^4.11.8",
     "camelcase": "^5.3.1",
+    "elliptic": "^6.0.0",
     "crypto-browserify": "^3.12.0",
     "crypto-js": "^3.1.9-1",
     "eslint-utils": "^1.4.2",


### PR DESCRIPTION
This project uses indirect dependency of `elliptic` here: https://github.com/binance-chain/javascript-sdk/blob/61823a9db1a5cee01d62fa89f0f7263134a6a9eb/src/crypto/index.js#L12 which may lead to undefined behavior when installing in pair with other dependencies that requires `elliptic` package, because of incorrect resolution of the dependency version. I guess this problem may appear mainly when using npm package manager rather than yarn as the project does not contain `package-lock.json`. 