### PR TITLE
Add `removePrivateKey` + `getPrivateKey` functions

### DIFF
--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -226,7 +226,7 @@ it("get swaps", async () => {
 
 it("works with a custom signing delegate", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const account = await client._httpClient.request(
     "get",
     `/api/v1/account/${addr}`
@@ -256,7 +256,7 @@ it("works with a custom signing delegate", async () => {
 
 it("works with a custom broadcast delegate", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const account = await client._httpClient.request(
     "get",
     `/api/v1/account/${addr}`
@@ -285,7 +285,7 @@ it("transfer placeOrder cancelOrder only", async () => {
 
   const symbol = "BNB_USDT.B-B7C"
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const accCode = crypto.decodeAddress(addr)
   const account = await client._httpClient.request(
     "get",
@@ -328,7 +328,7 @@ it("transfer with presicion", async () => {
   const coin = "BNB"
   let amount = 2.00177011
   const client = await getClient(false)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const account = await client._httpClient.request(
     "get",
     `/api/v1/account/${addr}`
@@ -360,7 +360,7 @@ it("transfer placeOrder cancelOrder (no await on set privkey)", async () => {
 
   const symbol = "BNB_USDT.B-B7C"
   const client = await getClient(false)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
 
   // acc needs .004 BNB to lock
   // IOC - auto cancels
@@ -451,7 +451,7 @@ it("get depth works", async () => {
 
 it("check number when transfer", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
 
   const account = await client._httpClient.request(
     "get",
@@ -489,7 +489,7 @@ it("check number when transfer", async () => {
 it("check number when place order", async () => {
   const symbol = "BNB_USDT.B-B7C"
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
 
   try {
     await client.placeOrder(addr, symbol, 2, -40, 0.0001, 1)
@@ -719,7 +719,7 @@ it("mint token", async () => {
 
 it("submitListProposal", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const date = new Date()
   const params = {
     title: "list MINT-200",
@@ -741,7 +741,7 @@ it("submitListProposal", async () => {
 
 it("depositProposal", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const coins = [
     {
       denom: "BNB",
@@ -756,7 +756,7 @@ it("depositProposal", async () => {
 
 it("voteProposal", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const res = await client.gov.vote(494, addr, voteOption.OptionYes)
   console.log(res)
   expect(res.status).toBe(200)
@@ -765,7 +765,7 @@ it("voteProposal", async () => {
 
 it("list MINT", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   try {
     const res = await client.list(addr, 620, "MINT-200", "BNB", 1)
     console.log(res)
@@ -778,8 +778,25 @@ it("list MINT", async () => {
 
 it("set account flags", async () => {
   const client = await getClient(true)
-  const addr = crypto.getAddressFromPrivateKey(client.privateKey)
+  const addr = crypto.getAddressFromPrivateKey(client.getPrivateKey())
   const res = await client.setAccountFlags(addr, 0x01)
   expect(res.status).toBe(200)
   expect(res.result[0].code).toBe(0)
+})
+
+it("can't get private key", async () => {
+  const client = await getClient(true, true)
+  expect(client.getPrivateKey()).toBeNull()
+})
+
+it("get private key", async () => {
+  const client = await getClient()
+  expect(client.getPrivateKey()).not.toBeNull()
+})
+
+it("remove private key", async () => {
+  const client = await getClient()
+  expect(client.getPrivateKey()).not.toBeNull()
+  client.removePrivateKey()
+  expect(client.getPrivateKey()).toBeNull()
 })

--- a/docs/jsdoc.md
+++ b/docs/jsdoc.md
@@ -53,6 +53,8 @@
             * [.initChain()](#module_client.BncClient+initChain) ⇒ <code>Promise</code>
             * [.chooseNetwork(network)](#module_client.BncClient+chooseNetwork)
             * [.setPrivateKey(privateKey, localOnly)](#module_client.BncClient+setPrivateKey) ⇒ <code>Promise</code>
+            * [.removePrivateKey()](#module_client.BncClient+removePrivateKey) ⇒ <code>BncClient</code>
+            * [.getPrivateKey()](#module_client.BncClient+getPrivateKey) ⇒ <code>string</code>
             * [.setAccountNumber(accountNumber)](#module_client.BncClient+setAccountNumber)
             * [.useAsyncBroadcast(useAsyncBroadcast)](#module_client.BncClient+useAsyncBroadcast) ⇒ <code>BncClient</code>
             * [.setSigningDelegate(delegate)](#module_client.BncClient+setSigningDelegate) ⇒ <code>BncClient</code>
@@ -65,6 +67,7 @@
             * [.cancelOrder(fromAddress, symbol, refid, sequence)](#module_client.BncClient+cancelOrder) ⇒ <code>Promise</code>
             * [.placeOrder(address, symbol, side, price, quantity, sequence, timeinforce)](#module_client.BncClient+placeOrder) ⇒ <code>Promise</code>
             * [.list(address, proposalId, baseAsset, quoteAsset, initPrice, sequence)](#module_client.BncClient+list) ⇒ <code>Promise</code>
+            * [.setAccountFlags(address, flags, sequence)](#module_client.BncClient+setAccountFlags) ⇒ <code>Promise</code>
             * [._prepareTransaction(msg, stdSignMsg, address, sequence, memo)](#module_client.BncClient+_prepareTransaction) ⇒ [<code>Transaction</code>](#Transaction)
             * [.sendTransaction(tx, sync)](#module_client.BncClient+sendTransaction) ⇒ <code>Promise</code>
             * [.sendRawTransaction(signedBz, sync)](#module_client.BncClient+sendRawTransaction) ⇒ <code>Promise</code>
@@ -106,6 +109,8 @@ The Binance Chain client.
     * [.initChain()](#module_client.BncClient+initChain) ⇒ <code>Promise</code>
     * [.chooseNetwork(network)](#module_client.BncClient+chooseNetwork)
     * [.setPrivateKey(privateKey, localOnly)](#module_client.BncClient+setPrivateKey) ⇒ <code>Promise</code>
+    * [.removePrivateKey()](#module_client.BncClient+removePrivateKey) ⇒ <code>BncClient</code>
+    * [.getPrivateKey()](#module_client.BncClient+getPrivateKey) ⇒ <code>string</code>
     * [.setAccountNumber(accountNumber)](#module_client.BncClient+setAccountNumber)
     * [.useAsyncBroadcast(useAsyncBroadcast)](#module_client.BncClient+useAsyncBroadcast) ⇒ <code>BncClient</code>
     * [.setSigningDelegate(delegate)](#module_client.BncClient+setSigningDelegate) ⇒ <code>BncClient</code>
@@ -118,6 +123,7 @@ The Binance Chain client.
     * [.cancelOrder(fromAddress, symbol, refid, sequence)](#module_client.BncClient+cancelOrder) ⇒ <code>Promise</code>
     * [.placeOrder(address, symbol, side, price, quantity, sequence, timeinforce)](#module_client.BncClient+placeOrder) ⇒ <code>Promise</code>
     * [.list(address, proposalId, baseAsset, quoteAsset, initPrice, sequence)](#module_client.BncClient+list) ⇒ <code>Promise</code>
+    * [.setAccountFlags(address, flags, sequence)](#module_client.BncClient+setAccountFlags) ⇒ <code>Promise</code>
     * [._prepareTransaction(msg, stdSignMsg, address, sequence, memo)](#module_client.BncClient+_prepareTransaction) ⇒ [<code>Transaction</code>](#Transaction)
     * [.sendTransaction(tx, sync)](#module_client.BncClient+sendTransaction) ⇒ <code>Promise</code>
     * [.sendRawTransaction(signedBz, sync)](#module_client.BncClient+sendRawTransaction) ⇒ <code>Promise</code>
@@ -180,6 +186,20 @@ Sets the client's private key for calls made by this client. Asynchronous.
 | privateKey | <code>string</code> |  | the private key hexstring |
 | localOnly | <code>boolean</code> | <code>false</code> | set this to true if you will supply an account_number yourself via `setAccountNumber`. Warning: You must do that if you set this to true! |
 
+<a name="module_client.BncClient+removePrivateKey"></a>
+
+#### bncClient.removePrivateKey() ⇒ <code>BncClient</code>
+Removes client's private key.
+
+**Kind**: instance method of [<code>BncClient</code>](#module_client.BncClient)  
+**Returns**: <code>BncClient</code> - this instance (for chaining)  
+<a name="module_client.BncClient+getPrivateKey"></a>
+
+#### bncClient.getPrivateKey() ⇒ <code>string</code>
+Gets client's private key.
+
+**Kind**: instance method of [<code>BncClient</code>](#module_client.BncClient)  
+**Returns**: <code>string</code> - the private key hexstring  
 <a name="module_client.BncClient+setAccountNumber"></a>
 
 #### bncClient.setAccountNumber(accountNumber)
@@ -358,6 +378,20 @@ Place an order.
 | baseAsset | <code>String</code> |  |  |
 | quoteAsset | <code>String</code> |  |  |
 | initPrice | <code>Number</code> |  |  |
+| sequence | <code>Number</code> | <code></code> | optional sequence |
+
+<a name="module_client.BncClient+setAccountFlags"></a>
+
+#### bncClient.setAccountFlags(address, flags, sequence) ⇒ <code>Promise</code>
+Set account flags
+
+**Kind**: instance method of [<code>BncClient</code>](#module_client.BncClient)  
+**Returns**: <code>Promise</code> - resolves with response (success or fail)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| address | <code>String</code> |  |  |
+| flags | <code>Number</code> |  | new value of account flags |
 | sequence | <code>Number</code> | <code></code> | optional sequence |
 
 <a name="module_client.BncClient+_prepareTransaction"></a>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -164,7 +164,6 @@ export class BncClient {
     if (privateKey !== this._privateKey) {
       const address = crypto.getAddressFromPrivateKey(privateKey, this.addressPrefix)
       if (!address) throw new Error(`address is falsy: ${address}. invalid private key?`)
-      if (address === this.address) return this // safety
       this._privateKey = privateKey
       this.address = address
       if (!localOnly) {


### PR DESCRIPTION
- [x] Add `removePrivateKey()` - Fixes #253 
- [x] Add a getter `getPrivateKey()` 
- [x] Rename `privateKey` to `_privateKey` to signal it's a private member of `BncClient`. It's accessible from outside world by using `getPrivateKey()` only now.