### PR TITLE
Generate declarations into `lib` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.2-alpha.8",
   "license": "Apache-2.0",
   "main": "lib/index.js",
-  "typings": "typings/index.d.ts",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest",
     "test:ledger": "qunit --require babel-polyfill tests-ledger/tests.js",
@@ -11,7 +11,7 @@
     "build": "yarn clean && tsc --emitDeclarationOnly && yarn build:docs && babel --extensions '.ts' src -d lib",
     "build:docs": "rimraf docs && typedoc --plugin typedoc-plugin-markdown --excludeExternals --excludeNotDocumented --readme none",
     "prepublishOnly": "npm run build",
-    "clean": "rimraf lib typings",
+    "clean": "rimraf lib",
     "lint": "eslint '**/*.{ts,js}'",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,json,md,html,yml}\""
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "declaration": true,
     "sourceMap": true,
     "rootDir": "./src",
-    "outDir": "typings",
+    "outDir": "lib",
     "strict": true,
     "skipLibCheck": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
to have these side-by-side with compiled `js` files and not in a separated "typings" directory. 

This will avoid issues such as 
```
Cannot find module '@binance-chain/javascript-sdk' or its corresponding type declarations.
```
while trying to import modules of `@binance-chain/javascript-sdk` into other TypeScript based projects. 

That's also the recommended way as described in [Publishing and bundling with your npm package](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) of official TypeScript documentation. 

If you want to separate `declarations` from compiled `js` files, check instruction about [Publish to @typings](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#publish-to-types)