### PR TITLE
Remove `static instance` from `TokenManager

### DIFF
--- a/src/client/token/index.ts
+++ b/src/client/token/index.ts
@@ -79,20 +79,13 @@ export const validateMiniTokenSymbol = (symbol: string) => {
  * issue or view tokens
  */
 class TokenManagement {
-  static instance: TokenManagement
-
   private _bncClient!: BncClient
 
   /**
    * @param {Object} bncClient
    */
   constructor(bncClient: BncClient) {
-    if (!TokenManagement.instance) {
-      this._bncClient = bncClient
-      TokenManagement.instance = this
-    }
-
-    return TokenManagement.instance
+    this._bncClient = bncClient
   }
 
   /**


### PR DESCRIPTION
By providing `TokenManager` like a singleton and storing a reference of an instance of `BncClient` only once in its constructor ([code here](https://github.com/binance-chain/javascript-sdk/blob/master/src/client/token/index.ts#L90-L93)), all new instances of `BncClient` will have same instance of `TokenManager` in `tokens` ([code here](https://github.com/binance-chain/javascript-sdk/blob/master/src/client/index.ts#L174)), but with another (first "passed") instance of `BncClient`. 

```
const c1 = new BncClient(...)
cosnt c2 = new BncClient(...)

// TokenManager of `c1.tokens` holds a reference to `c1` (in its `private _bncClient`)
// TokenManager of `c2.tokens` still holds same reference to `c1` - but it should be a reference to `c2`
```

That might cause issues in some case (_as we currently have had..._). 