### PR TITLE
Resolves Module "crypto" has no default export

### DIFF
--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -15,7 +15,7 @@ declare module "secure-random" {
 }
 
 declare module "crypto-browserify" {
-  import _crypto from "crypto"
+  import * as _crypto from "crypto"
   const crypto: Pick<
     typeof _crypto,
     | "createHash"


### PR DESCRIPTION
Resolves the following error in Angular

```
ERROR in node_modules/@binance-chain/javascript-sdk/lib/declarations.d.ts:15:12 - error TS1192: Module '"crypto"' has no default export.

15     import _crypto from "crypto";
```
closes #292 